### PR TITLE
setting up trusted proxies and forwarded headers

### DIFF
--- a/main.go
+++ b/main.go
@@ -55,6 +55,10 @@ func main() {
 		}
 	}()
 	router := gin.Default()
+	// refer to https://github.com/gin-gonic/gin/issues/2697#issuecomment-829071839
+	router.ForwardedByClientIP = true
+	router.SetTrustedProxies([]string{"0.0.0.0/0"})
+	router.RemoteIPHeaders = []string{"X-Forwarded-For", "X-Real-IP"}
 	router.Use(gin.Recovery())
 	router.Use(otelgin.Middleware("shorturl"))
 	router.GET("/healthz", func(c *gin.Context) {

--- a/methods/methods.go
+++ b/methods/methods.go
@@ -140,7 +140,7 @@ func Redirect(c *gin.Context, path string) {
 		log.Println("path is not cached, performing sql query to get the dst addr")
 		err := memstorage.SetValue(id, url)
 		if err != nil {
-			log.Fatalln("Unable to create entry in valkey ->", err)
+			log.Println("Unable to create entry in valkey ->", err)
 			span.RecordError(err)
 		}
 		c.Redirect(http.StatusPermanentRedirect, url)

--- a/urlshort/values.yaml
+++ b/urlshort/values.yaml
@@ -12,7 +12,7 @@ image:
   # This sets the pull policy for images.
   pullPolicy: IfNotPresent
   # Overrides the image tag whose default is the chart appVersion.
-  tag: "v0.1.0"
+  tag: "v0.2.1"
 
 # This is for the secrets for pulling an image from a private repository more information can be found here: https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry/
 imagePullSecrets: []


### PR DESCRIPTION
This PR specifies the trusted proxies as well as the forwarded headers, this is an attempt to prevent the pod restarting after trying out the redirect method inside of a kubernetes cluster